### PR TITLE
Correct stored SHA256 checksum

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 
 
 {% set version = "0.25.6" %}
-{% set sha256 = "7edb0e08a7c2fcf196e845a98e4bd019d445a2eb83fa4e4d5c0baf7d7876ddc1" %}
+{% set sha256 = "273b4271aafbdbcb330457976c90d4310620daf15cb0ca3cb16e82d3db0749c2" %}
 
 
 
@@ -17,7 +17,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:


### PR DESCRIPTION
See https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=231533&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=e5c8ab1d-8ff9-5cae-b332-e15ae582ed2d&l=1059

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)

I verified the new SHA256 checksum on my machine.